### PR TITLE
Use `super` when overriding `Point.new`.

### DIFF
--- a/03_constructor_parameter_method.rb
+++ b/03_constructor_parameter_method.rb
@@ -29,7 +29,7 @@ class Point
   attr_accessor :x, :y
 
   def self.new(x, y)
-    new.set(x: x, y: y)
+    super.set(x: x, y: y)
   end
   
   def set(options={})


### PR DESCRIPTION
A simple bug, in order to delegate to Object.new from within Point.new the `super` keyword needs to be used.
